### PR TITLE
Extract Timezone object

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timelib"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "A small Rust wrapper around the timelib library."

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ cargo add timelib
 ## Usage
 
 ```rust
-timelib::strtotime("tomorrow".into(), None, None);
-timelib::strtotime("next tuesday".into(), Some(1654318823), Some("America/Chicago".into()));
+let tz = timelib::Timezone::parse("America/Chicago".into()).expect("Error parsing timezone!");
+timelib::strtotime("tomorrow".into(), None, &tz);
+timelib::strtotime("next tuesday".into(), Some(1654318823), &tz);
 ```
 
 View the tests for more examples.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ impl Drop for Timezone {
 
 impl Timezone {
     /// Parses a String into a Timezone instance.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `timezone` - A String with your IANA Timezone name.
@@ -123,9 +123,7 @@ impl Timezone {
             if tzi.is_null() {
                 return Err(format!("Invalid timezone. Err: {error_code}."));
             }
-            Ok(Self {
-                tzi,
-            })
+            Ok(Self { tzi })
         }
     }
 }
@@ -202,11 +200,7 @@ mod tests {
         let tz = Timezone::parse("America/Chicago".into()).unwrap();
         let today = 1654318823; // Saturday, June 4, 2022 12:00:23 AM GMT-05:00 DST
         let tomorrow = 1654405200; // Sunday, June 5, 2022 12:00:00 AM GMT-05:00 DST
-        let result = strtotime(
-            "tomorrow".into(),
-            Some(today),
-            &tz,
-        );
+        let result = strtotime("tomorrow".into(), Some(today), &tz);
         assert!(result.is_ok());
         assert_eq!(tomorrow, result.unwrap());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use internal::*;
 /// # Examples
 ///
 /// ```
-/// let tz = timelib::Timezone::parse("America/Chicago".into()).unwrap();
+/// let tz = timelib::Timezone::parse("America/Chicago".into()).expect("Error parsing timezone!");
 /// timelib::strtotime("tomorrow".into(), None, &tz);
 /// timelib::strtotime("next tuesday".into(), Some(1654318823), &tz);
 /// ```


### PR DESCRIPTION
Fixes #6.

- Extract Timezone object.
- Fix `base` memory leak.